### PR TITLE
Bump Gradle Wrapper from 7.6 to 7.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bumps Gradle Wrapper from 7.6 to 7.6.

Release notes of Gradle 7.6 can be found here:
https://docs.gradle.org/7.6/release-notes.html