### PR TITLE
Dependency graph is submitted to GitHub on CI builds

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,6 +1,9 @@
 name: "Build Gradle project"
 on: [ push, pull_request, workflow_dispatch ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
      name: Test JVM (${{ matrix.java-version }})
@@ -18,6 +21,8 @@ jobs:
                distribution: 'liberica'
          - name: Setup Gradle
            uses: gradle/gradle-build-action@v2
+           with:
+               dependency-graph: generate-and-submit
          - name: Build with Gradle
            run: ./gradlew clean build -PtestJavaRuntimeVersion=${{ matrix.java-version }}
            env:


### PR DESCRIPTION
This PR updates the existing Gradle build workflow to also submit the dependency graph to GitHub.

You can see what this looks like on my fork of `gradle-jooq-plugin`: https://github.com/erichaagdev/gradle-jooq-plugin/network/dependencies