### PR TITLE
Publish build scans in dependency submission workflow

### DIFF
--- a/.github/workflows/gradle-dependency-graph.yml
+++ b/.github/workflows/gradle-dependency-graph.yml
@@ -20,3 +20,5 @@ jobs:
           java-version: 11
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4
+        with:
+          develocity-access-key: ${{ secrets.DV_ACCESS_KEY }}

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,7 +24,7 @@ buildCache {
     remote(develocity.buildCache) {
         enabled = true
         // Check access key presence to avoid build cache errors on PR builds when access key is not present
-        def accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
+        def accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
         push = isCI && accessKey
     }
 }


### PR DESCRIPTION
This PR configures the dependency submission action with an access key so a build scan is published. I also replaced `GRADLE_ENTERPRISE_ACCESS_KEY` with `DEVELOCITY_ACCESS_KEY` for the remote build cache push condition. 